### PR TITLE
[Doc] Arregla la bibliografía :bug: :memo:

### DIFF
--- a/doc/bibliografia.bib
+++ b/doc/bibliografia.bib
@@ -69,7 +69,7 @@
 } 
 
 @article{diversity,
-  author = {Burke and Edmund and Gustafson and Steven and Kendall and Graham},
+  author = {Burke, Edmund and Gustafson, Steven and Kendall, Graham},
   year = {2004},
   month = {03},
   pages = {47 - 62},
@@ -102,15 +102,16 @@
   title = {Real-Parameter Black-Box Optimization Benchmarking 2010: Presentation of the Noiseless Functions},
 }
 
-@misc{metaheuristics,
-  author = {Swan and Jerry and Adraensen and Steven and Brownlee and Alexander and Johnson and Colin and Kheiri and Ahmed and Krawiec and Faustyna and Merelo Guervós and Juan and Minku and Leandro and Özcan and Ender and Pappa and Gisele and García-Sánchez and Pablo and Sörensen and Kenneth and Voss and Stefan and Wagner and Markus and White and David},
-  year = {2020},
-  month = {11},
-  title = {Towards Metaheuristics ``In the Large``}
+@article{metaheuristics,
+  title={Metaheuristics “In the Large”},
+  author={Swan, Jerry and Adriaensen, Steven and Johnson, Colin G and Kheiri, Ahmed and Krawiec, Faustyna and Merelo, JJ and Minku, Leandro L and {\"O}zcan, Ender and Pappa, Gisele L and Garc{\'\i}a-S{\'a}nchez, Pablo and others},
+  journal={European Journal of Operational Research},
+  year={2021},
+  publisher={Elsevier}
 }
 
 @misc{julia,
-  author       = {Jeff Bezanson and Stefan Karpinski and Viral B. Shah and y otros contribuidores},
+  author       = {Jeff Bezanson and Stefan Karpinski and Viral B. Shah},
   title        = {Julia Programming Language},
   howpublished = {\url{https://julialang.org/}}
 }
@@ -169,7 +170,7 @@
 }
 
 @article{metaphor_exposed,
-  author = {Sörensen and Kenneth},
+  author = {Sörensen, Kenneth},
   title = {Metaheuristics—the metaphor exposed},
   journal = {International Transactions in Operational Research},
   volume = {22},
@@ -183,7 +184,7 @@
 }
 
 @article{mitigating_metaphors,
-  author = {Lones and Michael},
+  author = {Lones, Michael},
   year = {2019},
   month = {11},
   pages = {},
@@ -194,7 +195,7 @@
 }
 
 @article{comparative_study,
-  author = {Gmys and Jan and Pessoa and Tiago and Melab and Nouredine and Talbi and El-Ghazali and Tuyttens and Daniel},
+  author = {Gmys, Jan and Pessoa, Tiago and Melab, Nouredine and Talbi, El-Ghazali and Tuyttens, Daniel},
   year = {2020},
   month = {06},
   pages = {100720},
@@ -205,7 +206,7 @@
 }
 
 @misc{fast_lunch,
-  author = {Merelo Guervós and Juan and García-Sánchez and Pablo and Garcia-Valdez and Mario and Blancas and Israel},
+  author = {Merelo Guervós, Juan and García-Sánchez, Pablo and Garcia-Valdez, Mario and Blancas, Israel},
   year = {2015},
   month = {11},
   title = {There is no fast lunch: an examination of the running speed of evolutionary algorithms in several languages}
@@ -224,7 +225,7 @@
 }
 
 @article{585893,  
-  author={Wolpert and D.H. and Macready and W.G.},
+  author={Wolpert, D.H. and Macready, W.G.},
   journal={IEEE Transactions on Evolutionary Computation},
   title={No free lunch theorems for optimization},   
   year={1997},  


### PR DESCRIPTION
Revisa en general de todas formas y donde sea posible, extrae la entrada bib del propio artículo que lo deja exportar.